### PR TITLE
新增Env类;可用于区分生产环境和开发环境，以连接不同数据库等

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ vendor/
 .project
 .buildpath
 
+.idea

--- a/src/Env.php
+++ b/src/Env.php
@@ -17,10 +17,10 @@ final class Env
 
     public static $instance = null;
 
-    public static function init()
+    private static function init()
     {
-        if (empty(self::$file_path) && is_file(API_ROOT . '.env')) {
-            self::$file_path = API_ROOT . '.env';
+        if (empty(self::$file_path) && is_file(API_ROOT . '/.env')) {
+            self::$file_path = API_ROOT . '/.env';
         }
         if (empty(self::$env_array)) {
             self::$env_array = is_file(self::$file_path) ? parse_ini_file(self::$file_path, true) : [];
@@ -42,7 +42,7 @@ final class Env
         return self::$instance;
     }
 
-    public static function get($index, $default = null)
+    public static function get($index = '', $default = null)
     {
         self::init();
         if (strpos($index, '.')) {

--- a/src/Env.php
+++ b/src/Env.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * @author: Axios
+ *
+ * @email: axioscros@aliyun.com
+ * @blog:  http://hanxv.cn
+ * @datetime: 2017/7/11 13:37
+ */
+
+namespace PhalApi;
+
+final class Env
+{
+    public static $file_path = '';
+
+    public static $env_array = [];
+
+    public static $instance = null;
+
+    public static function init()
+    {
+        if (empty(self::$file_path) && is_file(API_ROOT . '.env')) {
+            self::$file_path = API_ROOT . '.env';
+        }
+        if (empty(self::$env_array)) {
+            self::$env_array = is_file(self::$file_path) ? parse_ini_file(self::$file_path, true) : [];
+        }
+        return self::$env_array;
+    }
+
+    public static function path($path)
+    {
+        if (is_null(self::$instance)) {
+            self::$instance = new static();
+        }
+        if (is_file($path)) {
+            self::$file_path = $path;
+            self::$env_array = parse_ini_file(self::$file_path, true);
+        } else {
+            throw new Exception($path . ' not found');
+        }
+        return self::$instance;
+    }
+
+    public static function get($index, $default = null)
+    {
+        self::init();
+        if (strpos($index, '.')) {
+            $indexArray = explode('.', $index);
+            $envData = self::$env_array;
+            $tmp = $envData;
+            foreach ($indexArray as $i) {
+                $tmp = isset($tmp[$i]) ? $tmp[$i] : null;
+                if (is_null($tmp)) {
+                    return $default;
+                }
+            }
+        } else {
+            $tmp = self::$env_array;
+            $tmp = isset($tmp[$index]) ? $tmp[$index] : null;
+            if (is_null($tmp)) {
+                return $default;
+            }
+        }
+        return $tmp;
+    }
+}


### PR DESCRIPTION
dbs.php数据库配置示例

``` shell
  'servers' => array(
        'db_master' => array(                         //服务器标记
            'host'      => \PhalApi\Env::get('mysql.host','127.0.0.1'),             //数据库域名
            'name'      => \PhalApi\Env::get('mysql.name','phalapi'),               //数据库名字
            'user'      => \PhalApi\Env::get('mysql.user','root'),                  //数据库用户名
            'password'  => \PhalApi\Env::get('mysql.password',''),	                    //数据库密码
            'port'      => \PhalApi\Env::get('mysql.port',3306),                  //数据库端口
            'charset'   => 'UTF8',                  //数据库字符集
        ),
    ),
```