### PR TITLE
NotORM 功能增强

### DIFF
--- a/src/Database/NotORMDatabase.php
+++ b/src/Database/NotORMDatabase.php
@@ -174,6 +174,13 @@ class NotORMDatabase /** implements Database */ {
     protected function getDBRouter($tableName, $suffix) {
         $rs = array('prefix' => '', 'key' => '', 'pdo' => NULL, 'isNoSuffix' => FALSE);
 
+        if (preg_match('/^(\S+)\.(\S+)$/', $tableName, $match)) {
+            $server = $match[1];
+            if (!isset($this->_configs['tables'][$tableName])) {
+                $this->_configs['tables'][$tableName] = array('map' => array(array('db' => $server)));
+            }
+        }
+
         $defaultMap = !empty($this->_configs['tables']['__default__']) 
             ? $this->_configs['tables']['__default__'] : array();
         $tableMap = !empty($this->_configs['tables'][$tableName]) 

--- a/src/DependenceInjection.php
+++ b/src/DependenceInjection.php
@@ -42,10 +42,10 @@ use PhalApi\Exception\InternalServerErrorException;
  * @property \PhalApi\Crypt          $crypt      加密
  * @property \PhalApi\Config         $config     配置
  * @property \PhalApi\Logger         $logger     日记
- * @property \PhalApi\DB\NotORM      $notorm     数据库
+ * @property \PhalApi\Database\NotORMDatabase      $notorm     数据库
  * @property \PhalApi\Loader         $loader     自动加载
  * @property \PhalApi\Helper\Tracer  $tracer     全球追踪器
- * 
+ * @property \PhalApi\Cache\RedisCache $redis    redis
  * @package     PhalApi\DependenceInjection
  * @link        http://docs.phalconphp.com/en/latest/reference/di.html 实现统一的资源设置、获取与管理，支持延时加载
  * @license     http://www.phalapi.net/license GPL 协议

--- a/src/Model/NotORMModel.php
+++ b/src/Model/NotORMModel.php
@@ -126,6 +126,16 @@ class NotORMModel implements Model {
         return \PhalApi\DI()->notorm->$table;
     }
 
+    /**
+     * 快速获取指定table的ORM实例.
+     * @param string $table 表名可指定服务器,比如demo2.user
+     * @return \NotORM_Result
+     */
+    protected function table($table)
+    {
+        return \PhalApi\DI()->notorm->$table;
+    }
+
     protected function loadTableKeys() {
         $tables = \PhalApi\DI()->config->get('dbs.tables');
         if (empty($tables)) {

--- a/src/Model/NotORMModel.php
+++ b/src/Model/NotORMModel.php
@@ -119,7 +119,7 @@ class NotORMModel implements Model {
     /**
      * 快速获取ORM实例，注意每次获取都是新的实例
      * @param string/int $id
-     * @return NotORM_Result
+     * @return \NotORM_Result
      */
     protected function getORM($id = NULL) {
         $table = $this->getTableName($id);


### PR DESCRIPTION
 NotORM 功能强化
    1.  在NotORMModel中可以直接$this->table($table)来快速切换table.
    2. 上面$table可以指定数据库服务器.
    3. 同时修正两个相关的PHPDOC内容(对自动完成的编辑器友好).
```php
    //快速访问demo数据库服务器的user表
    //在数据库配置(dbs.php)中不需要有 demo.user 的tables配置信息.
   //在NotORMModel类中可以直接使用以下方法,该功能对于需要同时访问多个数据时比较方便
    $this->table('demo.user')->where('1=0')->fetchAll();
```