### PR TITLE
请求参数增加默认的快速配置方法

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -43,6 +43,10 @@ class Api {
      * @var boolean $__apiIsServiceWhitelist 是否为白名单服务
      */
     private $__apiIsServiceWhitelist;
+    /**
+     * @var array $Rules API参数列表,具体的参数规则由配置文件rules指定.
+     */
+    protected $Rules = array();
 
     /**
      * 设置规则解析后的接口参数
@@ -158,7 +162,53 @@ class Api {
      * @return array
      */
     public function getRules() {
-        return array();
+        if (empty($this->Rules)) {
+            return array();
+        }
+        $root = DI()->request->getNamespace();
+        $allrules = DI()->config->get('rules@' . $root, array());
+        if (empty($allrules)) {
+            $allrules = DI()->config->get('rules', array());
+        }
+        if (empty($allrules)) {
+            return array();
+        }
+        $path = new \ReflectionClass($this);
+        $root_dir = dirname($path->getFileName());
+        $rules = array();
+            //通用的参数规则获取方法,并且自动生成相应的类文件(用于自动完成)
+        foreach ($this->Rules as $k => $v) {
+            $params = is_string($v) ? explode(',', $v) : $v;
+            $data = [];
+            foreach ($params as $key) {
+                $keyp = explode(':', $key);
+                $key = $keyp[0];
+                $data[$key] = $allrules[$key];
+                $data[$key]['name'] = $key;
+                if (isset($keyp[1])) {
+                    $data[$key]['require'] = $keyp[1];
+                }
+            }
+            $rules[$k] = $data;
+            if (!class_exists('\\' . $root . '\\Data\\' . $k)) {
+                $line = [];
+                foreach ($rules[$k] as $key => $value) {
+                    $vType = $value['type'] == 'array' ? $value['name'] : $value['type'];
+                    $line[] = "/** @var {$vType} {$value['desc']} */\npublic \${$value['name']};";
+                }
+                file_put_contents($root_dir . '/../Data/' . $k . '.php', "<?php\nnamespace ${root}\Data;\nclass $k {\n" . implode("\r\n", $line) . "\n}");
+            }
+        }
+            //公用参数合并到每一个API
+        if (isset($rules['common'])) {
+            foreach ($rules as $k => &$v) {
+                if ($k != 'common') {
+                    $v = array_merge($rules['common'], $v);
+                }
+            }
+        }
+
+        return $rules;
     }
 
     /**


### PR DESCRIPTION
相关issue
https://github.com/phalapi/phalapi/issues/60
使用方法:
1. 在config目录中增加rules.php配置文件(所有需要的参数规则).
```
return array(
    //所有参数规则列表,require参数在调用时可以额外指定.
    'param1' => array('type' => 'string', 'require' => 1, 'max' => 64, 'desc' => '参数1的说明'),
    'param2' => array('type' => 'int', 'require' => 0, 'default' => '', 'desc' => '参数2的说明'),
    'param3' => array('type' => 'array','require' => 0, 'desc' => '参数3的说明'),
)
```
注: 如果需要配置多APP,可以使用rules@appname.php 作为配置文件.

2. 在api中不再需要重写getRules函数了,直接使用变量指定需要的参数
```
class Site extends Api
{
    protected $Rules = array(
        //site下所有API都需要的参数
        'common' => 'param1,param2',
        //特定API的参数,参数后面可以使用:x 或指定是否必填,如下指定在index的API中params3是必填的.
        'index' => 'param3:1',
    }
    //API的实现.
 );
```