### PR TITLE
首页导航 /docs.php 会自动去根目录下, 改为docs.php

### DIFF
--- a/src/Helper/api_desc_tpl.php
+++ b/src/Helper/api_desc_tpl.php
@@ -21,7 +21,7 @@ echo <<<EOT
 
   <div class="ui fixed inverted menu">
     <div class="ui container">
-      <a href="/docs.php" class="header item">
+      <a href="docs.php" class="header item">
         <img class="logo" src="http://7xiz2f.com1.z0.glb.clouddn.com/20180316214150_f6f390e686d0397f1f1d6a66320864d6">
         {$projectName}
       </a>

--- a/src/Helper/api_list_tpl.php
+++ b/src/Helper/api_list_tpl.php
@@ -18,7 +18,7 @@ $table_color_arr = explode(" ", "red orange yellow olive teal blue violet purple
 
   <div class="ui fixed inverted menu">
     <div class="ui container">
-      <a href="/docs.php" class="header item">
+      <a href="docs.php" class="header item">
         <img class="logo" src="http://7xiz2f.com1.z0.glb.clouddn.com/20180316214150_f6f390e686d0397f1f1d6a66320864d6">
         <?php echo $projectName; ?>
       </a>


### PR DESCRIPTION
###  如下图,当框架不在根目录时,点击导航上的'Api接口文档'链接会自动去根目录下

![](http://temp-customs-1251903635.coscd.myqcloud.com/temp_ihogo/%E5%BE%AE%E4%BF%A1%E6%88%AA%E5%9B%BE_20180910140158.png)