### PR TITLE
默认MD5签名增加分隔符,防止位移篡改参数

### DIFF
--- a/src/Filter/SimpleMD5Filter.php
+++ b/src/Filter/SimpleMD5Filter.php
@@ -27,7 +27,7 @@ class SimpleMD5Filter implements Filter {
     protected $signName;
     protected $separator;
 
-    public function __construct($signName = 'sign',$separator = '=') {
+    public function __construct($signName = 'sign', $separator = false) {
         $this->signName = $signName;
         $this->separator = $separator;
     }
@@ -54,8 +54,10 @@ class SimpleMD5Filter implements Filter {
 
         $paramsStrExceptSign = '';
         foreach ($params as $index => $val) {
-            if (isset($val) && $val) {
+            if($this->separator && isset($val) && $val){
                 $paramsStrExceptSign .= $index . $this->separator . $val;
+            }else{
+                $paramsStrExceptSign .= $val;
             }
         }
 

--- a/src/Filter/SimpleMD5Filter.php
+++ b/src/Filter/SimpleMD5Filter.php
@@ -25,9 +25,11 @@ use PhalApi\Exception\BadRequestException;
 class SimpleMD5Filter implements Filter {
 
     protected $signName;
+    protected $separator;
 
-    public function __construct($signName = 'sign') {
+    public function __construct($signName = 'sign',$separator = '=') {
         $this->signName = $signName;
+        $this->separator = $separator;
     }
 
     public function check() {
@@ -51,8 +53,10 @@ class SimpleMD5Filter implements Filter {
         ksort($params);
 
         $paramsStrExceptSign = '';
-        foreach ($params as $val) {
-            $paramsStrExceptSign .= $val;
+        foreach ($params as $index => $val) {
+            if (isset($val) && $val) {
+                $paramsStrExceptSign .= $index . $this->separator . $val;
+            }
         }
 
         return md5($paramsStrExceptSign);

--- a/src/Filter/SimpleMD5Filter.php
+++ b/src/Filter/SimpleMD5Filter.php
@@ -55,7 +55,7 @@ class SimpleMD5Filter implements Filter {
         $paramsStrExceptSign = '';
         foreach ($params as $index => $val) {
             if($this->separator && isset($val) && $val){
-                $paramsStrExceptSign .= $index . $this->separator . $val;
+                $paramsStrExceptSign .= ($index . $this->separator . $val);
             }else{
                 $paramsStrExceptSign .= $val;
             }


### PR DESCRIPTION
请求1: ?s=Order.insert&total_fee=100&phone=18887655655

请求2: ?s=Order.insert&total_fee=1001888&phone=7655655

签名串:Order.insert10018887655655

请求1和请求2的签名串是一致的,获取到请求参数后,可以通过参数位移来串改参数,但是sign值是对的

文档需要改动
1.签名参数排除了空值
2.默认分隔符为"="